### PR TITLE
fast forward request data on completion of begin_callback()

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -2472,6 +2472,24 @@ static int pull_all(FILE *fp, struct mg_connection *conn, char *buf, int len)
     return nread;
 }
 
+static void fast_forward_request(struct mg_connection *conn)
+{
+    char buf[MG_BUF_LEN];
+    int to_read, nread;
+
+    while (conn->consumed_content < conn->content_len) {
+        to_read = sizeof(buf);
+        if ((int64_t) to_read > conn->content_len - conn->consumed_content) {
+            to_read = (int) (conn->content_len - conn->consumed_content);
+        }
+
+	nread = mg_read(conn, buf, to_read);
+        if (nread <= 0) {
+            break;
+        }
+    }
+}
+
 int mg_read(struct mg_connection *conn, void *buf, size_t len)
 {
     int64_t n, buffered_len, nread;
@@ -6269,6 +6287,7 @@ static void handle_request(struct mg_connection *conn)
     /* 8. check if there are request handlers for this path */
     if (conn->ctx->request_handlers != NULL && use_request_handler(conn)) {
         /* Do nothing, callback has served the request */
+	fast_forward_request(conn);
         return;
     }
 


### PR DESCRIPTION
backend might not have read all data, we need to make sure we flush all
incoming data.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>