### PR TITLE
call setgroups() to avoid supplemental group leakage

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -6651,6 +6651,8 @@ static int set_uid_option(struct mg_context *ctx)
             mg_cry(fc(ctx), "%s: unknown user [%s]", __func__, uid);
         } else if (setgid(pw->pw_gid) == -1) {
             mg_cry(fc(ctx), "%s: setgid(%s): %s", __func__, uid, strerror(errno));
+        } else if (setgroups(0, NULL)) {
+            mg_cry(fc(ctx), "%s: setgroups(): %s", __func__, strerror(errno));
         } else if (setuid(pw->pw_uid) == -1) {
             mg_cry(fc(ctx), "%s: setuid(%s): %s", __func__, uid, strerror(errno));
         } else {


### PR DESCRIPTION
Calling setgroups() between setgid() and setuid().

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>