### PR TITLE
Call of handler before context save (C++ Wrapper)

### DIFF
--- a/src/CivetServer.cpp
+++ b/src/CivetServer.cpp
@@ -57,7 +57,7 @@ int CivetServer::requestHandler(struct mg_connection *conn, void *cbdata)
     assert(me != NULL);
 
     // Happens when a request hits the server before the context is saved
-    if (me->context == NULL) return;
+    if (me->context == NULL) return 0;
 
     mg_lock_context(me->context);
     me->connections[conn] = CivetConnection();

--- a/src/CivetServer.cpp
+++ b/src/CivetServer.cpp
@@ -55,6 +55,10 @@ int CivetServer::requestHandler(struct mg_connection *conn, void *cbdata)
     assert(request_info != NULL);
     CivetServer *me = (CivetServer*) (request_info->user_data);
     assert(me != NULL);
+
+    // Happens when a request hits the server before the context is saved
+    if (me->context == NULL) return;
+
     mg_lock_context(me->context);
     me->connections[conn] = CivetConnection();
     mg_unlock_context(me->context);
@@ -106,6 +110,9 @@ void CivetServer::closeHandler(struct mg_connection *conn)
     assert(request_info != NULL);
     CivetServer *me = (CivetServer*) (request_info->user_data);
     assert(me != NULL);
+
+    // Happens when a request hits the server before the context is saved
+    if (me->context == NULL) return;
 
     if (me->userCloseHandler) me->userCloseHandler(conn);
     mg_lock_context(me->context);


### PR DESCRIPTION
I had it happen multiple times, that the closeHandler is called while the context was still null (during the constructor of CivetServer), resulting in a segfault.

It's crude hack, but I wanted the bug to be known.