### PR TITLE
Helper function mg_construct_msg for generating well-formed HTTP respons...

### DIFF
--- a/examples/response/Makefile
+++ b/examples/response/Makefile
@@ -1,9 +1,9 @@
 # 
-# Copyright (c) 2013 No Face Press, LLC
+# Copyright (c) 2015 the Civetweb developers
 # License http://opensource.org/licenses/mit-license.php MIT License
 #
 
-#This makefile is used to test the other Makefiles
+#Build the response example demonstrating use of response helper functions
 
 
 PROG = response

--- a/examples/response/Makefile
+++ b/examples/response/Makefile
@@ -1,0 +1,36 @@
+# 
+# Copyright (c) 2013 No Face Press, LLC
+# License http://opensource.org/licenses/mit-license.php MIT License
+#
+
+#This makefile is used to test the other Makefiles
+
+
+PROG = response
+SRC = response.c
+
+TOP = ../..
+CIVETWEB_LIB = libcivetweb.a
+
+CFLAGS = -I$(TOP)/include $(COPT)
+LIBS = -lpthread
+
+include $(TOP)/resources/Makefile.in-os
+
+ifeq ($(TARGET_OS),LINUX) 
+	LIBS += -ldl
+endif
+
+all: $(PROG)
+
+$(PROG): $(CIVETWEB_LIB) $(SRC)
+	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $(SRC) $(CIVETWEB_LIB) $(LIBS)
+
+$(CIVETWEB_LIB):
+	$(MAKE) -C $(TOP) clean lib
+	cp $(TOP)/$(CIVETWEB_LIB) .
+
+clean:
+	rm -f $(CIVETWEB_LIB) $(PROG)
+
+.PHONY: all clean

--- a/examples/response/response.c
+++ b/examples/response/response.c
@@ -1,0 +1,70 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "civetweb.h"
+
+// This function will be called by civetweb on every new request.
+static int begin_request_handler(struct mg_connection *conn)
+{
+    const struct mg_request_info *request_info = mg_get_request_info(conn);
+    char content[100];
+
+    // Prepare the message we're going to send
+    int content_length = snprintf(content, sizeof(content),
+                                  "Hello from civetweb! Remote port: %d\r\n",
+                                  request_info->remote_port);
+
+    char buffer[32];
+    snprintf(buffer, sizeof(buffer), "%d", content_length);
+
+    // Send HTTP reply to the client
+    const char *header_data[] = {
+        "Content-Type", "text/plain",
+        "Content-Length", buffer,
+        NULL
+    };
+
+    struct mg_response_header *headers = mg_construct_response_headers(header_data);
+
+    // Construct a response message
+    size_t len = 0;
+    void *response = mg_construct_response_msg(conn, "1.1", 200, "OK", headers, content, content_length, &len);
+
+    // free memory allocated by headers
+    mg_free_response_headers(&headers);
+
+    // send the response
+    mg_write(conn, response, len);
+
+    // free the response buffer
+    mg_free_response_msg(&response);
+
+    // Returning non-zero tells civetweb that our function has replied to
+    // the client, and civetweb should not send client any more data.
+    return 1;
+}
+
+int main(void)
+{
+    struct mg_context *ctx;
+    struct mg_callbacks callbacks;
+
+    // List of options. Last element must be NULL.
+    const char *options[] = {"listening_ports", "8080", NULL};
+
+    // Prepare callbacks structure. We have only one callback, the rest are NULL.
+    memset(&callbacks, 0, sizeof(callbacks));
+    callbacks.begin_request = begin_request_handler;
+
+    // Start the web server.
+    ctx = mg_start(&callbacks, NULL, options);
+
+    // Wait until user hits "enter". Server is running in separate thread.
+    // Navigating to http://localhost:8080 will invoke begin_request_handler().
+    getchar();
+
+    // Stop the server.
+    mg_stop(ctx);
+
+    return 0;
+}

--- a/examples/response/response.c
+++ b/examples/response/response.c
@@ -1,3 +1,6 @@
+//Copyright (c) 2013-2015 the Civetweb developers
+//This example demonstrates the use of the response functions
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/include/civetweb.h
+++ b/include/civetweb.h
@@ -78,6 +78,12 @@ struct mg_request_info {
     } http_headers[64];         /* Maximum 64 headers */
 };
 
+/* Linked-List response header */
+struct mg_response_header {
+   char *name;
+   char *value;
+   struct mg_response_header *next;
+};
 
 /* This structure needs to be passed to mg_start(), to let civetweb know
    which callbacks to invoke. For a detailed description, see
@@ -343,6 +349,22 @@ CIVETWEB_API int mg_modify_passwords_file(const char *passwords_file_name,
 /* Return information associated with the request. */
 CIVETWEB_API struct mg_request_info *mg_get_request_info(struct mg_connection *);
 
+/* Returns list of headers */
+CIVETWEB_API struct mg_response_header *mg_construct_response_headers(const char **headers);
+
+/* frees memory allocated in mg_construct_headers*/
+CIVETWEB_API void mg_free_response_headers(struct mg_response_header **headers);
+
+/* Constructs a HTTP Response, return param must be free'd by mg_free_response_msg
+ *
+   Return:
+     NULL if failed to construct response otherwise a pointer to a c string containing
+     the formatted response */
+CIVETWEB_API void *mg_construct_response_msg(struct mg_connection * conn, const char *http_version, int status_code,
+                          const char *status_msg, struct mg_response_header *, const void *buf, size_t len, size_t *len_out);
+
+/* Free buffer allocated by mg_construct_response_msg */
+CIVETWEB_API void mg_free_response_msg(void **dst);
 
 /* Send data to the client.
    Return:


### PR DESCRIPTION
I've added a response helper function as I didn't like having to manually format the response (with the \r\n details and that)

Included an example showing how to use it/proof that it works

