### PR TITLE
linking fails because clock_gettime is missing without -lrt flag on ubun...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ endif
 # only set main compile options if none were chosen
 CFLAGS += -W -Wall -O2 -D$(TARGET_OS) -Iinclude $(COPT) -DUSE_STACK_SIZE=102400
 
-LIBS = -lpthread -lm
+LIBS = -lpthread -lm -lrt
 
 ifdef WITH_DEBUG
   CFLAGS += -g -DDEBUG_ENABLED


### PR DESCRIPTION
Mostly just a comment that I had to add this flag to compile on Debian. Debian is stupid, so it's probably a Debian problem. I don't know what the side effects on other Linux flavors would be to add this flag, so I just thought I'd post here that I needed this flag to make it work. 