### PR TITLE
Makefile fixes/changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,11 @@ slib: lib$(CPROG).$(SHARED_LIB)
 
 clean:
 	$(RMRF) $(BUILD_DIR)
+	$(eval version=$(shell grep "define CIVETWEB_VERSION" include/civetweb.h | sed 's|.*VERSION "\(.*\)"|\1|g'))
+	$(eval major=$(shell echo $(version) | cut -d'.' -f1))
+	$(RMRF) lib$(CPROG).so
+	$(RMRF) lib$(CPROG).so.$(major)
+	$(RMRF) lib$(CPROG).so.$(version).0
 
 distclean: clean
 	@$(RMRF) VS2012/Debug VS2012/*/Debug  VS2012/*/*/Debug
@@ -237,7 +242,11 @@ lib$(CPROG).a: $(LIB_OBJECTS)
 
 lib$(CPROG).so: CFLAGS += -fPIC
 lib$(CPROG).so: $(LIB_OBJECTS)
-	$(LCC) -shared -o $@ $(CFLAGS) $(LDFLAGS) $(LIB_OBJECTS)
+	$(eval version=$(shell grep "define CIVETWEB_VERSION" include/civetweb.h | sed 's|.*VERSION "\(.*\)"|\1|g'))
+	$(eval major=$(shell echo $(version) | cut -d'.' -f1))
+	$(LCC) -shared -Wl,-soname,$@.$(major) -o $@.$(version).0 $(CFLAGS) $(LDFLAGS) $(LIB_OBJECTS)
+	ln -s -f $@.$(major) $@
+	ln -s -f $@.$(version).0 $@.$(major)
 
 lib$(CPROG).dll: CFLAGS += -fPIC
 lib$(CPROG).dll: $(LIB_OBJECTS)

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ endif
 ifdef WITH_CPP
   OBJECTS += src/CivetServer.o
   LCC = $(CXX)
+  CFLAGS += -std=c++11
 else
   LCC = $(CC)
 endif


### PR DESCRIPTION
This MR address two issues:

1. Added -std=c++11 flag to makefile. 
When compiling the C++ interface on linux (via make WITH_CPP=1 command) I encountered errors like
"identifier ‘nullptr’ is a keyword in C++11."

2. Added the soname property.
I made this change in order to have the final output match conventions used for other libraries on linux.
This change reads the CIVETWEB_VERSION define in civetweb.h and uses that to determine the soname & the output filename (e.g. libcivetweb.so.1.7.0) Then two symlinks are created; a libcivetweb.so.1 and a libcivetweb.so, both pointing to the 1.7.0 file).

also updated the clean action to remove all .so's produced.

This change is based on information from:
http://tldp.org/HOWTO/Program-Library-HOWTO/shared-libraries.html