### PR TITLE
Fix erroneous merge error when starting request and no content-len set

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -7386,7 +7386,6 @@ static int getreq(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *
                    !mg_strcasecmp(conn->request_info.request_method, "PUT")) {
             /* POST or PUT request without content length set */
             conn->content_len = -1;
-            conn->content_len = 0;
         } else if (!mg_strncasecmp(conn->request_info.request_method, "HTTP/", 5)) {
             /* Response without content length set */
             conn->content_len = -1;


### PR DESCRIPTION
* When no content-length header is encountered and we're in a PUT or
  POST request - restore prior behavior initializing content_len to -1
  rather than 0. It was a rather innocuous error, but good to restore
  prior behavior.