### PR TITLE
Cannot cast Lua function pointer in standard C

### DIFF
--- a/src/mod_lua.inl
+++ b/src/mod_lua.inl
@@ -1162,7 +1162,9 @@ void mg_exec_lua_script(struct mg_connection *conn, const char *path,
             lua_pushglobaltable(L);
             for (i = 0; exports[i] != NULL && exports[i + 1] != NULL; i += 2) {
                 lua_pushstring(L, (const char *)(exports[i]));
-                lua_pushcclosure(L, (lua_CFunction) exports[i + 1], 0);
+                lua_CFunction func;
+                *(const void**)(&func) = exports[i + 1];
+                lua_pushcclosure(L, func, 0);
                 lua_rawset(L, -3);
             }
         }


### PR DESCRIPTION
src/civetweb.c:5533:0:
src/mod_lua.inl: In function ‘mg_exec_lua_script’:
src/mod_lua.inl:1169:37: error: ISO C forbids conversion of object
  pointer to function pointer type [-Wpedantic]
      lua_pushcclosure(L, (lua_CFunction) exports[i + 1], 0);
                              ^

This patch uses the POSIX.1-2003 workaround.
See linux.die.net/man/3/dlsym