### PR TITLE
Only include -lrt if on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,9 @@ ifdef WITH_WEBSOCKET
   CFLAGS += -DUSE_WEBSOCKET
   ifdef WITH_LUA
     CFLAGS += -DUSE_TIMERS
-    LIBS += -lrt
+    ifeq ($(TARGET_OS),LINUX)
+      LIBS += -lrt
+    endif
   endif
 endif
 


### PR DESCRIPTION
Small patch, just fixes compiling on OSX.