### PR TITLE
AIX, HPUX, Solaris build fixes, socklen_t 64bit fix for HPUX

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -43,6 +43,10 @@
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS   /* C++ wants that for INT64_MAX */
 #endif
+#ifdef __sun
+#define __EXTENSIONS__	/* to expose flockfile and friends in stdio.h */ 
+#define __inline inline	/* not recognized on older compiler versions */
+#endif
 #endif
 
 #if defined (_MSC_VER)
@@ -1044,7 +1048,7 @@ void mg_set_thread_name(const char* name)
 #elif defined(BSD) || defined(__FreeBSD__) || defined(__OpenBSD__)
    /* BSD (TODO: test) */
    pthread_set_name_np(pthread_self(), threadName);
-#elif defined(_AIX) ||  defined(__hpux)
+#elif defined(_AIX) || defined(__hpux) || defined(__sun)
    /* no name function */
 #else
    /* POSIX */


### PR DESCRIPTION
Neither AIX 5 or HPUX 11 define va_copy or have a thread name
function.  Move existing va_copy #define out of a windows-only block
so that it can apply to any platform that needs it.

The HPUX system headers mistakenly define socklen_t as a 64bit value
on Itanium, and has function prototypes with socklen_t when compiling
with _XOPEN_SOURCE.  However, the socket functions actually expect a
pointer to a 32bit value.  Passing address of socklen_t rather than
int results in zero data returned, missing client net address from
the accept() and general badness.  Fix by forcing a redef of socklen_t
to int when building on HPUX.

Signed-off-by: David Loffredo <loffredo@steptools.com>