### PR TITLE
Add -fPIC in compiling option to allow it to link to shared library under Ubuntu.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,7 @@ distclean: clean
 	$(RMF) $(CPROG) lib$(CPROG).so lib$(CPROG).a *.dmg *.msi *.exe lib$(CPROG).dll lib$(CPROG).dll.a
 	$(RMF) $(UNIT_TEST_PROG)
 
+lib$(CPROG).a: CFLAGS += -fPIC
 lib$(CPROG).a: $(LIB_OBJECTS)
 	@$(RMF) $@
 	ar cq $@ $(LIB_OBJECTS)


### PR DESCRIPTION
Without this -fPIC, following link error will appear:

/usr/bin/ld: ../modules/civetweb/libcivetweb.a(civetweb.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
../modules/civetweb/libcivetweb.a: error adding symbols: Bad value