### PR TITLE
Add -fPIC for static linked library.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,7 @@ distclean: clean
 	$(RMF) $(CPROG) lib$(CPROG).so lib$(CPROG).a *.dmg *.msi *.exe lib$(CPROG).dll lib$(CPROG).dll.a
 	$(RMF) $(UNIT_TEST_PROG)
 
+lib$(CPROG).a: CFLAGS += -fPIC
 lib$(CPROG).a: $(LIB_OBJECTS)
 	@$(RMF) $@
 	ar cq $@ $(LIB_OBJECTS)


### PR DESCRIPTION
Right now -fPIC is used for .dll and .so (dynamic linked option), we need to add -fPIC for static link option too, as it could be used in a library who is dynamic linked.