### PR TITLE
Minor change to civetweb.c

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -8803,7 +8803,7 @@ getreq(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 	} else if (parse_http_message(
 	               conn->buf, conn->buf_size, &conn->request_info) <= 0) {
 		snprintf(
-		    ebuf, ebuf_len, "Bad request: [%.*s]", conn->data_len, conn->buf);
+		    ebuf, ebuf_len, "Bad request: [len=%d]", conn->data_len);
 		*err = 400;
 		return 0;
 	} else {


### PR DESCRIPTION
When reporting an error if parse_http_message were to fail, sending back user input as is to the client poses a security risk to browsers. I propose removing the string in the error reporting.