### PR TITLE
Compilation fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ BUILD_DIRS += $(BUILD_DIR)/test
 endif
 
 # only set main compile options if none were chosen
-CFLAGS += -Wall -Wextra -O2 -D$(TARGET_OS) -Iinclude $(COPT) -DUSE_STACK_SIZE=102400
+CFLAGS += -Wall -Wextra -Wshadow -Wmissing-prototypes -Wsign-conversion -O2 -D$(TARGET_OS) -Iinclude $(COPT) -DUSE_STACK_SIZE=102400
 
 LIBS = -lpthread -lm
 

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -6253,16 +6253,16 @@ static void send_ssi_file(struct mg_connection *conn,
 				mg_cry(conn, "%s: SSI tag is too large", path);
 				len = 0;
 			}
-			buf[len++] = ch & 0xff;
+			buf[len++] = (char)(ch & 0xff);
 		} else if (ch == '<') {
 			in_ssi_tag = 1;
 			if (len > 0) {
 				mg_write(conn, buf, (size_t)len);
 			}
 			len = 0;
-			buf[len++] = ch & 0xff;
+			buf[len++] = (char)(ch & 0xff);
 		} else {
-			buf[len++] = ch & 0xff;
+			buf[len++] = (char)(ch & 0xff);
 			if (len == (int)sizeof(buf)) {
 				mg_write(conn, buf, (size_t)len);
 				len = 0;

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -501,7 +501,7 @@ DEBUG_TRACE_FUNC(const char *func, unsigned line, const char *fmt, ...)
 	DEBUG_TRACE_FUNC(__func__, __LINE__, fmt, __VA_ARGS__)
 
 #else
-#define DEBUG_TRACE(fmt, ...)
+#define DEBUG_TRACE(fmt, ...) do {} while(0)
 #endif /* DEBUG */
 #endif /* DEBUG_TRACE */
 

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -9146,10 +9146,9 @@ static void process_new_connection(struct mg_connection *conn)
 			/*assert(discard_len >= 0);*/
 			if (discard_len < 0)
 				break;
-			memmove(conn->buf,
-			        conn->buf + discard_len,
-			        conn->data_len - discard_len);
 			conn->data_len -= discard_len;
+			if (conn->data_len > 0)
+				memmove(conn->buf, conn->buf + discard_len, (size_t)conn->data_len);
 
 			/* assert(conn->data_len >= 0); */
 			/* assert(conn->data_len <= conn->buf_size); */

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -2035,7 +2035,7 @@ send_http_error(struct mg_connection *conn, int status, const char *fmt, ...)
 			buf[len] = 0;
 
 			va_start(ap, fmt);
-			len += mg_vsnprintf(conn, buf + len, sizeof(buf) - len, fmt, ap);
+			len += mg_vsnprintf(conn, buf + len, sizeof(buf) - (size_t)len, fmt, ap);
 			va_end(ap);
 		}
 		DEBUG_TRACE("[%s]", buf);

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -7240,7 +7240,8 @@ int mg_upload(struct mg_connection *conn, const char *destination_dir)
 				memmove(buf, &buf[len - bl], bl);
 				len = bl;
 			}
-		} while (!eof && (n = mg_read(conn, buf + len, sizeof(buf) - len)) > 0);
+			n = mg_read(conn, buf + len, sizeof(buf) - ((size_t)(len)));
+		} while (!eof && (n > 0));
 		fclose(fp);
 		if (eof) {
 			remove(path);

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -63,6 +63,10 @@
  * replacement function here. */
 #if defined(_MSC_VER) && (_MSC_VER >= 1600)
 #define mg_static_assert static_assert
+#elif defined(__cplusplus) && (__cplusplus >= 201103L)
+#define mg_static_assert static_assert
+#elif defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#define mg_static_assert _Static_assert
 #else
 char static_assert_replacement[1];
 #define mg_static_assert(cond, txt)                                            \

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -1072,7 +1072,7 @@ static int is_websocket_protocol(const struct mg_connection *conn);
 #define is_websocket_protocol(conn) (0)
 #endif
 
-int mg_atomic_inc(volatile int *addr)
+static int mg_atomic_inc(volatile int *addr)
 {
 	int ret;
 #if defined(_WIN32) && !defined(__SYMBIAN32__)
@@ -1088,7 +1088,7 @@ int mg_atomic_inc(volatile int *addr)
 	return ret;
 }
 
-int mg_atomic_dec(volatile int *addr)
+static int mg_atomic_dec(volatile int *addr)
 {
 	int ret;
 #if defined(_WIN32) && !defined(__SYMBIAN32__)
@@ -1121,7 +1121,7 @@ typedef struct tagTHREADNAME_INFO {
 #include <sys/prctl.h>
 #endif
 
-void mg_set_thread_name(const char *name)
+static void mg_set_thread_name(const char *name)
 {
 	char threadName[16]; /* Max. thread length in Linux/OSX/.. */
 
@@ -3023,7 +3023,7 @@ static void discard_unread_request_data(struct mg_connection *conn)
 	}
 }
 
-int mg_read_inner(struct mg_connection *conn, void *buf, size_t len)
+static int mg_read_inner(struct mg_connection *conn, void *buf, size_t len)
 {
 	int64_t n, buffered_len, nread;
 	int64_t len64 =
@@ -3279,7 +3279,7 @@ static int alloc_vprintf(char **buf, size_t size, const char *fmt, va_list ap)
 	return len;
 }
 
-int mg_vprintf(struct mg_connection *conn, const char *fmt, va_list ap)
+static int mg_vprintf(struct mg_connection *conn, const char *fmt, va_list ap)
 {
 	char mem[MG_BUF_LEN], *buf = mem;
 	int len;
@@ -7977,7 +7977,8 @@ static void close_all_listening_sockets(struct mg_context *ctx)
 
 static int is_valid_port(unsigned int port) { return port < 0xffff; }
 
-int mg_inet_pton(int af, const char *src, void *dst)
+#if defined(USE_IPV6)
+static int mg_inet_pton(int af, const char *src, void *dst)
 {
 	struct addrinfo hints, *res, *ressave;
 
@@ -7999,6 +8000,7 @@ int mg_inet_pton(int af, const char *src, void *dst)
 	freeaddrinfo(ressave);
 	return (ressave != NULL);
 }
+#endif
 
 /* Valid listening port specification is: [ip_address:]port[s]
  * Examples: 80, 443s, 127.0.0.1:3128, 1.2.3.4:8080s

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -5174,8 +5174,8 @@ static void parse_http_headers(char **buf, struct mg_request_info *ri)
 		ri->http_headers[i].value = skip(buf, "\r\n");
 		if (ri->http_headers[i].name[0] == '\0')
 			break;
-		ri->num_headers = i + 1;
 	}
+	ri->num_headers = i;
 }
 
 static int is_valid_http_method(const char *method)

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -66,7 +66,7 @@
 #else
 char static_assert_replacement[1];
 #define mg_static_assert(cond, txt)                                            \
-	extern char static_assert_replacement[(cond) ? 1 : -1];
+	extern char static_assert_replacement[(cond) ? 1 : -1]
 #endif
 
 mg_static_assert(sizeof(int) == 4 || sizeof(int) == 8,

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -7047,8 +7047,8 @@ static int parse_net(const char *spec, uint32_t *net, uint32_t *mask)
 	    isbyte(a) && isbyte(b) && isbyte(c) && isbyte(d) && slash >= 0 &&
 	    slash < 33) {
 		len = n;
-		*net =
-		    ((uint32_t)a << 24) | ((uint32_t)b << 16) | ((uint32_t)c << 8) | d;
+		*net = ((uint32_t)a << 24) | ((uint32_t)b << 16) | ((uint32_t)c << 8) |
+		        (uint32_t)d;
 		*mask = slash ? 0xffffffffU << (32 - slash) : 0;
 	}
 

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -968,35 +968,35 @@ struct mg_request_handler_info {
 };
 
 struct mg_context {
-	volatile int stop_flag;        /* Should we stop event loop */
-	SSL_CTX *ssl_ctx;              /* SSL context */
-	char *config[NUM_OPTIONS];     /* Civetweb configuration parameters */
-	struct mg_callbacks callbacks; /* User-defined callback function */
-	void *user_data;               /* User-defined data */
-	int context_type;              /* 1 = server context, 2 = client context */
+	volatile int stop_flag;         /* Should we stop event loop */
+	SSL_CTX *ssl_ctx;               /* SSL context */
+	char *config[NUM_OPTIONS];      /* Civetweb configuration parameters */
+	struct mg_callbacks callbacks;  /* User-defined callback function */
+	void *user_data;                /* User-defined data */
+	int context_type;               /* 1 = server context, 2 = client context */
 
 	struct socket *listening_sockets;
 	in_port_t *listening_ports;
 	int num_listening_sockets;
 
-	volatile int num_threads;     /* Number of threads */
-	pthread_mutex_t thread_mutex; /* Protects (max|num)_threads */
-	pthread_cond_t thread_cond; /* Condvar for tracking workers terminations */
+	volatile int num_threads;       /* Number of threads */
+	pthread_mutex_t thread_mutex;   /* Protects (max|num)_threads */
+	pthread_cond_t thread_cond;     /* Condvar for tracking workers terminations */
 
-	struct socket queue[MGSQLEN]; /* Accepted sockets */
-	volatile int sq_head;         /* Head of the socket queue */
-	volatile int sq_tail;         /* Tail of the socket queue */
-	pthread_cond_t sq_full;       /* Signaled when socket is produced */
-	pthread_cond_t sq_empty;      /* Signaled when socket is consumed */
-	pthread_t masterthreadid;     /* The master thread ID */
-	int workerthreadcount;        /* The amount of worker threads. */
-	pthread_t *workerthreadids;   /* The worker thread IDs */
+	struct socket queue[MGSQLEN];   /* Accepted sockets */
+	volatile int sq_head;           /* Head of the socket queue */
+	volatile int sq_tail;           /* Tail of the socket queue */
+	pthread_cond_t sq_full;         /* Signaled when socket is produced */
+	pthread_cond_t sq_empty;        /* Signaled when socket is consumed */
+	pthread_t masterthreadid;       /* The master thread ID */
+	int workerthreadcount;          /* The amount of worker threads. */
+	pthread_t *workerthreadids;     /* The worker thread IDs */
 
-	unsigned long start_time; /* Server start time, used for authentication */
-	pthread_mutex_t nonce_mutex; /* Protects nonce_count */
-	unsigned long nonce_count;   /* Used nonces, used for authentication */
+	unsigned long start_time;       /* Server start time, used for authentication */
+	pthread_mutex_t nonce_mutex;    /* Protects nonce_count */
+	unsigned long nonce_count;      /* Used nonces, used for authentication */
 
-	char *systemName; /* What operating system is running */
+	char *systemName;               /* What operating system is running */
 
 	/* linked list of uri handlers */
 	struct mg_request_handler_info *request_handlers;

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -3981,7 +3981,7 @@ char *mg_md5(char buf[33], ...)
 
 	va_start(ap, buf);
 	while ((p = va_arg(ap, const char *)) != NULL) {
-		md5_append(&ctx, (const md5_byte_t *)p, (int)strlen(p));
+		md5_append(&ctx, (const md5_byte_t *)p, strlen(p));
 	}
 	va_end(ap);
 

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -8035,7 +8035,9 @@ static int parse_port_string(const struct vec *vec, struct socket *so)
 		/* TODO: check -- so->lsa.sin6.sin6_port = htons((uint16_t) port); */
 		so->lsa.sin.sin_port = htons((uint16_t)port);
 	} else {
-		port = len = 0; /* Parsing failure. Make port invalid. */
+		 /* Parsing failure. Make port invalid. */
+		port = 0;
+		len = 0;
 	}
 
 	/* sscanf and the option splitting code ensure the following condition */

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -8837,7 +8837,7 @@ getreq(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 		/* Message is a valid request or response */
 		if ((cl = get_header(&conn->request_info, "Content-Length")) != NULL) {
 			/* Request/response has content length set */
-			char *endptr = "";
+			char *endptr;
 			conn->content_len = strtoll(cl, &endptr, 10);
 			if (endptr == cl) {
 				snprintf(ebuf, ebuf_len, "%s", "Bad Request");

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -3106,14 +3106,14 @@ int mg_read(struct mg_connection *conn, void *buf, size_t len)
 			if (conn->chunk_remainder) {
 				/* copy from the remainder of the last received chunk */
 				long read_ret;
-				int read_now = (int)((conn->chunk_remainder > len)
+				size_t read_now = ((conn->chunk_remainder > len)
 				                         ? (len)
 				                         : (conn->chunk_remainder));
 
-				conn->content_len += read_now;
+				conn->content_len += (int)read_now;
 				read_ret =
 				    mg_read_inner(conn, (char *)buf + all_read, read_now);
-				all_read += read_ret;
+				all_read += (size_t)read_ret;
 
 				conn->chunk_remainder -= read_now;
 				len -= read_now;

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -1299,9 +1299,9 @@ static char *mg_strdup(const char *str) { return mg_strndup(str, strlen(str)); }
 
 static const char *mg_strcasestr(const char *big_str, const char *small_str)
 {
-	int i, big_len = (int)strlen(big_str), small_len = (int)strlen(small_str);
+	size_t i, big_len = strlen(big_str), small_len = strlen(small_str);
 
-	for (i = 0; i <= big_len - small_len; i++) {
+	for (i = 0; i <= (big_len - small_len); i++) {
 		if (mg_strncasecmp(big_str + i, small_str, small_len) == 0) {
 			return big_str + i;
 		}

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -8408,7 +8408,8 @@ static int cryptolib_users = 0; /* Reference counter for crypto library. */
 
 static int initialize_ssl(struct mg_context *ctx)
 {
-	int i, size;
+	int i;
+	size_t size;
 
 #if !defined(NO_SSL_DL)
 	if (!cryptolib_dll_handle) {
@@ -8425,8 +8426,11 @@ static int initialize_ssl(struct mg_context *ctx)
 	/* Initialize locking callbacks, needed for thread safety.
 	 * http://www.openssl.org/support/faq.html#PROG1
 	 */
-	size = sizeof(pthread_mutex_t) * CRYPTO_num_locks();
-	if ((ssl_mutexes = (pthread_mutex_t *)mg_malloc((size_t)size)) == NULL) {
+	i = CRYPTO_num_locks();
+	if (i < 0)
+		i = 0;
+	size = sizeof(pthread_mutex_t) * ((size_t)(i));
+	if ((ssl_mutexes = (pthread_mutex_t *)mg_malloc(size)) == NULL) {
 		mg_cry(
 		    fc(ctx), "%s: cannot allocate mutexes: %s", __func__, ssl_error());
 		return 0;

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -2989,7 +2989,8 @@ static int pull_all(FILE *fp, struct mg_connection *conn, char *buf, int len)
 static void discard_unread_request_data(struct mg_connection *conn)
 {
 	char buf[MG_BUF_LEN];
-	int to_read, nread;
+	size_t to_read;
+	int nread;
 
 	if (conn == NULL) {
 		return;
@@ -3010,9 +3011,8 @@ static void discard_unread_request_data(struct mg_connection *conn)
 	} else {
 		/* Not chunked: content length is known */
 		while (conn->consumed_content < conn->content_len) {
-			if ((int64_t)to_read >
-			    (conn->content_len - conn->consumed_content)) {
-				to_read = (int)(conn->content_len - conn->consumed_content);
+			if (to_read > (size_t)(conn->content_len - conn->consumed_content)) {
+				to_read = (size_t)(conn->content_len - conn->consumed_content);
 			}
 
 			nread = mg_read(conn, buf, to_read);

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -977,7 +977,7 @@ struct mg_context {
 
 	struct socket *listening_sockets;
 	in_port_t *listening_ports;
-	int num_listening_sockets;
+	unsigned int num_listening_sockets;
 
 	volatile int num_threads;       /* Number of threads */
 	pthread_mutex_t thread_mutex;   /* Protects (max|num)_threads */
@@ -1424,7 +1424,7 @@ mg_get_ports(const struct mg_context *ctx, size_t size, int *ports, int *ssl)
 	if (!ctx) {
 		return 0;
 	}
-	for (i = 0; i < size && i < (size_t)ctx->num_listening_sockets; i++) {
+	for (i = 0; i < size && i < ctx->num_listening_sockets; i++) {
 		ssl[i] = ctx->listening_sockets[i].is_ssl;
 		ports[i] = ctx->listening_ports[i];
 	}
@@ -7255,10 +7255,11 @@ int mg_upload(struct mg_connection *conn, const char *destination_dir)
 
 static int get_first_ssl_listener_index(const struct mg_context *ctx)
 {
-	int i, idx = -1;
+	unsigned int i;
+	int idx = -1;
 	if (ctx)
 		for (i = 0; idx == -1 && i < ctx->num_listening_sockets; i++) {
-			idx = ctx->listening_sockets[i].is_ssl ? i : -1;
+			idx = ctx->listening_sockets[i].is_ssl ? ((int)(i)) : -1;
 		}
 	return idx;
 }
@@ -7955,7 +7956,7 @@ static void handle_file_based_request(struct mg_connection *conn,
 
 static void close_all_listening_sockets(struct mg_context *ctx)
 {
-	int i;
+	unsigned int i;
 	if (!ctx)
 		return;
 

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -7138,7 +7138,7 @@ int mg_upload(struct mg_connection *conn, const char *destination_dir)
 		/* assert(len >= 0 && len <= (int) sizeof(buf)); */
 		if (len < 0 || len > (int)sizeof(buf))
 			break;
-		while ((n = mg_read(conn, buf + len, sizeof(buf) - len)) > 0) {
+		while ((n = mg_read(conn, buf + len, sizeof(buf) - (size_t)len)) > 0) {
 			len += n;
 			/* assert(len <= (int) sizeof(buf)); */
 			if (len > (int)sizeof(buf))
@@ -7153,7 +7153,7 @@ int mg_upload(struct mg_connection *conn, const char *destination_dir)
 
 		/* Scan for the boundary string and skip it */
 		if (buf[0] == '-' && buf[1] == '-' &&
-		    !memcmp(buf + 2, boundary, boundary_len)) {
+		    !memcmp(buf + 2, boundary, (size_t)boundary_len)) {
 			s = &buf[bl];
 		} else {
 			s = &buf[2];
@@ -7217,7 +7217,7 @@ int mg_upload(struct mg_connection *conn, const char *destination_dir)
 		/* assert(len >= headers_len); */
 		if (len < headers_len)
 			break;
-		memmove(buf, &buf[headers_len], len - headers_len);
+		memmove(buf, &buf[headers_len], (size_t)(len - headers_len));
 		len -= headers_len;
 
 		/* Read POST data, write into file until boundary is found. */
@@ -7226,18 +7226,18 @@ int mg_upload(struct mg_connection *conn, const char *destination_dir)
 			len += n;
 			for (i = 0; i < len - bl; i++) {
 				if (!memcmp(&buf[i], "\r\n--", 4) &&
-				    !memcmp(&buf[i + 4], boundary, boundary_len)) {
+				    !memcmp(&buf[i + 4], boundary, (size_t)boundary_len)) {
 					/* Found boundary, that's the end of file data. */
-					fwrite(buf, 1, i, fp);
+					fwrite(buf, 1, (size_t)i, fp);
 					eof = 1;
-					memmove(buf, &buf[i + bl], len - (i + bl));
+					memmove(buf, &buf[i + bl], (size_t)(len - (i + bl)));
 					len -= i + bl;
 					break;
 				}
 			}
 			if (!eof && len > bl) {
-				fwrite(buf, 1, len - bl, fp);
-				memmove(buf, &buf[len - bl], bl);
+				fwrite(buf, 1, (size_t)(len - bl), fp);
+				memmove(buf, &buf[len - bl], (size_t)bl);
 				len = bl;
 			}
 			n = mg_read(conn, buf + len, sizeof(buf) - ((size_t)(len)));

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -5432,9 +5432,9 @@ forward_body_data(struct mg_connection *conn, FILE *fp, SOCKET sock, SSL *ssl)
 struct cgi_env_block {
 	struct mg_connection *conn;
 	char buf[CGI_ENVIRONMENT_SIZE]; /* Environment buffer */
-	int len;                        /* Space taken */
+	unsigned int len;               /* Space taken */
 	char *vars[MAX_CGI_ENVIR_VARS]; /* char **envp */
-	int nvars;                      /* Number of variables */
+	unsigned int nvars;             /* Number of variables */
 };
 
 static char *addenv(struct cgi_env_block *block,
@@ -5468,11 +5468,11 @@ static char *addenv(struct cgi_env_block *block, const char *fmt, ...)
 
 	/* Make sure we do not overflow buffer and the envp array */
 	if (n > 0 && n + 1 < space &&
-	    block->nvars < (int)ARRAY_SIZE(block->vars) - 2) {
+	    block->nvars + 2 < ARRAY_SIZE(block->vars)) {
 		/* Append a pointer to the added string into the envp array */
 		block->vars[block->nvars++] = added;
 		/* Bump up used length counter. Include \0 terminator */
-		block->len += n + 1;
+		block->len += (unsigned int)(n) + 1;
 	} else {
 		mg_cry(block->conn,
 		       "%s: CGI env buffer truncated for [%s]",

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -3183,7 +3183,7 @@ int mg_write(struct mg_connection *conn, const void *buf, size_t len)
 		}
 		allowed = conn->throttle - conn->last_throttle_bytes;
 		if (allowed > (int64_t)len) {
-			allowed = len;
+			allowed = (int64_t)len;
 		}
 		if ((total = push(NULL,
 		                  conn->client.sock,

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -4206,10 +4206,8 @@ static char *mg_fgets(char *buf, size_t size, struct file *filep, char **p)
 
 	if (filep->membuf != NULL && *p != NULL) {
 		memend = (char *)&filep->membuf[filep->size];
-		eof = (char *)memchr(
-		    *p,
-		    '\n',
-		    memend - *p); /* Search for \n from p till the end of stream */
+		 /* Search for \n from p till the end of stream */
+		eof = (char *)memchr(*p, '\n', (size_t)(memend - *p));
 		if (eof != NULL) {
 			eof += 1; /* Include \n */
 		} else {

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -1654,12 +1654,12 @@ next_option(const char *list, struct vec *val, struct vec *eq_val)
 		val->ptr = list;
 		if ((list = strchr(val->ptr, ',')) != NULL) {
 			/* Comma found. Store length and shift the list ptr */
-			val->len = list - val->ptr;
+			val->len = ((size_t)(list - val->ptr));
 			list++;
 		} else {
 			/* This value is the last one */
 			list = val->ptr + strlen(val->ptr);
-			val->len = list - val->ptr;
+			val->len = ((size_t)(list - val->ptr));
 		}
 
 		if (eq_val != NULL) {
@@ -1669,8 +1669,8 @@ next_option(const char *list, struct vec *val, struct vec *eq_val)
 			eq_val->ptr = (const char *)memchr(val->ptr, '=', val->len);
 			if (eq_val->ptr != NULL) {
 				eq_val->ptr++; /* Skip over '=' character */
-				eq_val->len = val->ptr + val->len - eq_val->ptr;
-				val->len = (eq_val->ptr - val->ptr) - 1;
+				eq_val->len = ((size_t)(val->ptr - eq_val->ptr)) + val->len;
+				val->len = ((size_t)(eq_val->ptr - val->ptr)) - 1;
 			}
 		}
 	}

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -5824,11 +5824,12 @@ static int put_dir(struct mg_connection *conn, const char *path)
 	char buf[PATH_MAX];
 	const char *s, *p;
 	struct file file = STRUCT_FILE_INITIALIZER;
-	int len, res = 1;
+	size_t len;
+	int res = 1;
 
 	for (s = p = path + 2; (p = strchr(s, '/')) != NULL; s = ++p) {
-		len = (int)(p - path);
-		if (len >= (int)sizeof(buf)) {
+		len = (size_t)(p - path);
+		if (len >= sizeof(buf)) {
 			/* path too long */
 			res = -1;
 			break;

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -3224,7 +3224,7 @@ int mg_write(struct mg_connection *conn, const void *buf, size_t len)
 static int alloc_vprintf2(char **buf, const char *fmt, va_list ap)
 {
 	va_list ap_copy;
-	int size = MG_BUF_LEN;
+	size_t size = MG_BUF_LEN;
 	int len = -1;
 
 	*buf = NULL;

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -4814,8 +4814,8 @@ static int remove_directory(struct mg_connection *conn, const char *dir)
 
 struct dir_scan_data {
 	struct de *entries;
-	int num_entries;
-	int arr_size;
+	unsigned int num_entries;
+	unsigned int arr_size;
 };
 
 /* Behaves like realloc(), but frees original pointer on failure */
@@ -4851,7 +4851,8 @@ static void dir_scan_callback(struct de *de, void *data)
 static void handle_directory_request(struct mg_connection *conn,
                                      const char *dir)
 {
-	int i, sort_direction;
+	unsigned int i;
+	int sort_direction;
 	struct dir_scan_data data = {NULL, 0, 128};
 	char date[64];
 	time_t curtime = time(NULL);

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -3267,7 +3267,7 @@ static int alloc_vprintf(char **buf, size_t size, const char *fmt, va_list ap)
 		va_copy(ap_copy, ap);
 		len = alloc_vprintf2(buf, fmt, ap);
 		va_end(ap_copy);
-	} else if (len > (int)size && (size = len + 1) > 0 &&
+	} else if ((size_t)(len) > size && (size = (size_t)(len) + 1) > 0 &&
 	           (*buf = (char *)mg_malloc(size)) == NULL) {
 		len = -1; /* Allocation failed, mark failure */
 	} else {

--- a/src/main.c
+++ b/src/main.c
@@ -738,7 +738,7 @@ static void start_civetweb(int argc, char *argv[]) {
 	}
 }
 
-void stop_civetweb(void) {
+static void stop_civetweb(void) {
 	mg_stop(g_ctx);
 	free(g_user_data.first_message);
 	g_user_data.first_message = NULL;

--- a/src/md5.inl
+++ b/src/md5.inl
@@ -66,7 +66,7 @@ MD5_STATIC void md5_init(md5_state_t *pms);
 
 /* Append a string to the message. */
 MD5_STATIC void md5_append(md5_state_t *pms, const md5_byte_t *data,
-                           int nbytes);
+                           size_t nbytes);
 
 /* Finish the message and return the digest. */
 MD5_STATIC void md5_finish(md5_state_t *pms, md5_byte_t digest[16]);
@@ -403,10 +403,10 @@ MD5_STATIC void md5_init(md5_state_t *pms) {
 }
 
 MD5_STATIC void md5_append(md5_state_t *pms, const md5_byte_t *data,
-                           int nbytes) {
+                           size_t nbytes) {
 	const md5_byte_t *p = data;
-	int left = nbytes;
-	int offset = (pms->count[0] >> 3) & 63;
+	size_t left = nbytes;
+	size_t offset = (pms->count[0] >> 3) & 63;
 	md5_word_t nbits = (md5_word_t)(nbytes << 3);
 
 	if (nbytes <= 0)
@@ -420,7 +420,7 @@ MD5_STATIC void md5_append(md5_state_t *pms, const md5_byte_t *data,
 
 	/* Process an initial partial block. */
 	if (offset) {
-		int copy = (offset + nbytes > 64 ? 64 - offset : nbytes);
+		size_t copy = (offset + nbytes > 64 ? 64 - offset : nbytes);
 
 		memcpy(pms->buf + offset, p, copy);
 		if (offset + copy < 64)

--- a/src/md5.inl
+++ b/src/md5.inl
@@ -269,7 +269,8 @@ static void md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/) {
 #define xbuf X /* (static only) */
 #endif
 			for (i = 0; i < 16; ++i, xp += 4)
-				xbuf[i] = xp[0] + (xp[1] << 8) + (xp[2] << 16) + (xp[3] << 24);
+				xbuf[i] = (md5_word_t)(xp[0]) + (md5_word_t)(xp[1] << 8) +
+				          (md5_word_t)(xp[2] << 16) + (md5_word_t)(xp[3] << 24);
 		}
 #endif
 	}


### PR DESCRIPTION
The cmake branch is going to enable a lot more warnings as errors to make the code in the project more concise. The two warnings that occur frequently in the code are missing prototypes and implicit sign conversions. I'm putting this up to attempt to get it into master so that _hopefully_ any new code will watch for those two errors (especially the sign conversion) and not break on other platforms.

The missing prototype errors are pretty simple. The functions that are defined do not have a corresponding declaration so they should either add one, because they are public API functions, or be made `static` because they are private non-public functions. I've gone with the latter. They are solved in a single commit at the end of the branch.

The sign conversions are a much more complicated. There are a lot of instances where integers are given to functions that expect `size_t` and the integer is implicit converted to a unsigned integer. In other situations casting is happening with arithmetic that could be causing overflow or a number of other bugs. Implicit casts can lead to subtle bugs:

```
int some_write_function(FILE * const fp, uint8_t * const buffer, size_t count);

/* This is attempting to write the rest of the buffer out, however, if sent_length is greater than
 * length we end up with a implicit cast of a negative number to size_t and the function sees
 * a HUGE count of bytes to write
 */
some_write_function(fp, buf + sent_length, length - sent_length);
```

I've attempted to make the patches as _small_ as possible so that they can be reviewed individually and `git cherry-pick`ed if necessary. I tried to make the commit messages for each commit as descriptive as possible so that the information about the sign conversion fix isn't lost.

There are a few patches that change the signedness in the public structures. This is usually for situations where the member of the struct is conveying a _count_ or _size_ of something that should never be negative. Rather than fixing up all of the implicit sign conversions from `int` to `unsigned`, I've changed the type so that it is `unsigned` so that the sign conversion errors are therefore fixed and the structure member is more semantically correct. These are controversial changes and I'm completely flexible on what we do here.

Due to the fact that implicit conversions are now required to be explicit it has revealed quite a few situations where I've tried to make the best decision I can with respect to the way to solve the errors. We should be telling the compiler what it should be doing when it has to convert between unsigned and signed and in some situations I've found the code to be a bit ambiguous (or confusing) to completely understand what to do. In those situations I've made the implicit cast that the compiler is doing explicit so that the code will function as before (but could quite possibly be incorrect and a bug) but shouldn't introduce any _new_ bugs.

I've tested this with `gcc` on Arch Linux and it compiles without error with the new warnings added to the Makefile. I need some help to understand how to run all the unit tests on the code.