### PR TITLE
Resolve Mac OS X 10.9 compilation warning

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -127,6 +127,8 @@ mg_static_assert(sizeof(void *) >= sizeof(int), "data type size check");
 #include <assert.h>
 
 /* clock_gettime is not implemented on OSX */
+int clock_gettime(int clk_id, struct timespec *t);
+
 int clock_gettime(int clk_id, struct timespec *t)
 {
 	if (clk_id == CLOCK_REALTIME) {


### PR DESCRIPTION

    cc -c -Wall -Wextra -Wshadow -Wformat-security -Winit-self -Wmissing-prototypes -O2 -DOSX -Iinclude  -DUSE_STACK_SIZE=102400 -DNDEBUG src/civetweb.c -o out/src/civetweb.o
    src/civetweb.c:130:5: warning: no previous prototype for function 'clock_gettime' [-Wmissing-prototypes]
    int clock_gettime(int clk_id, struct timespec *t)
        ^
    1 warning generated.