### PR TITLE
check, refactor, isolation

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -1152,10 +1152,6 @@ typedef struct tagTHREADNAME_INFO {
 #include <sys/sendfile.h>
 #endif
 
-#if ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12)))
-#define GLIBC_CHK
-#endif
-
 static void mg_set_thread_name(const char *name)
 {
 	char threadName[16]; /* Max. thread length in Linux/OSX/.. */

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -432,15 +432,19 @@ static char *read_conn(struct mg_connection *conn, int *size)
 	return data;
 }
 
+#ifdef MEMORY_DEBUGGING
 extern unsigned long mg_memory_debug_blockCount;
 extern unsigned long mg_memory_debug_totalMemUsed;
+#endif
 
 static void ut_mg_stop(struct mg_context *ctx)
 {
 	/* mg_stop for unit_test */
 	mg_stop(ctx);
+#ifdef MEMORY_DEBUGGING
 	ASSERT(mg_memory_debug_blockCount == 0);
 	ASSERT(mg_memory_debug_totalMemUsed == 0);
+#endif
 	mg_sleep(
 	    31000); /* This is required to ensure the operating system already
 	               allows to use the port again */


### PR DESCRIPTION
- check ctx before use
- refactor ifdefs : to safely use pthread_setname_np we can only check the glibc's version, no need to check the system. In case of linux, if the glibc is too old, we can use the old prctl function. It's is maybe possible to do the same on other architectures, i didn't check.
- isolate variables used for the memory debugging