### PR TITLE
Fix Appveyor Dependency

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -103,4 +103,4 @@ matrix:
   fast_finish: true
 
 cache:
-  - C:\mingw-builds -> mingw.py
+  - C:\mingw-builds -> mingw.cmd


### PR DESCRIPTION
The mingw-builds downloads need to be flushed whenever the download script
changes. It used to use a python script but has changed to a batch script.

Part of #147.