### PR TITLE
Porting Unit Tests to CMake

### DIFF
--- a/test/civetweb_check.h
+++ b/test/civetweb_check.h
@@ -33,6 +33,7 @@
 /* Unreferenced formal parameter. START_TEST has _i */
 #pragma warning(disable: 4100)
 #endif
+#include <stdint.h>
 #include <check.h>
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/test/private.c
+++ b/test/private.c
@@ -37,7 +37,45 @@
 
 START_TEST (test_parse_http_message)
 {
-  fail_if(0, "s not null after free");
+  struct mg_request_info ri;
+  char req1[] = "GET / HTTP/1.1\r\n\r\n";
+  char req2[] = "BLAH / HTTP/1.1\r\n\r\n";
+  char req3[] = "GET / HTTP/1.1\r\nBah\r\n";
+  char req4[] = "GET / HTTP/1.1\r\nA: foo bar\r\nB: bar\r\nbaz\r\n\r\n";
+  char req5[] = "GET / HTTP/1.1\r\n\r\n";
+  char req6[] = "G";
+  char req7[] = " blah ";
+  char req8[] = " HTTP/1.1 200 OK \n\n";
+  char req9[] = "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n";
+
+  ck_assert_int_eq(sizeof(req9) - 1, parse_http_message(req9, sizeof(req9), &ri));
+  ck_assert_int_eq(1, ri.num_headers);
+
+  ck_assert_int_eq(sizeof(req1) - 1, parse_http_message(req1, sizeof(req1), &ri));
+  ck_assert_str_eq("1.1", ri.http_version);
+  ck_assert_int_eq(0, ri.num_headers);
+
+  ck_assert_int_eq(-1, parse_http_message(req2, sizeof(req2), &ri));
+  ck_assert_int_eq(0, parse_http_message(req3, sizeof(req3), &ri));
+  ck_assert_int_eq(0, parse_http_message(req6, sizeof(req6), &ri));
+  ck_assert_int_eq(0, parse_http_message(req7, sizeof(req7), &ri));
+  ck_assert_int_eq(0, parse_http_message("", 0, &ri));
+  ck_assert_int_eq(sizeof(req8) - 1, parse_http_message(req8, sizeof(req8), &ri));
+
+  /* TODO(lsm): Fix this. Header value may span multiple lines. */
+  ck_assert_int_eq(sizeof(req4) - 1, parse_http_message(req4, sizeof(req4), &ri));
+  ck_assert_str_eq("1.1", ri.http_version);
+  ck_assert_int_eq(3, ri.num_headers);
+  ck_assert_str_eq("A", ri.http_headers[0].name);
+  ck_assert_str_eq("foo bar", ri.http_headers[0].value);
+  ck_assert_str_eq("B", ri.http_headers[1].name);
+  ck_assert_str_eq("bar", ri.http_headers[1].value);
+  ck_assert_str_eq("baz\r\n\r", ri.http_headers[2].name);
+  ck_assert_str_eq("", ri.http_headers[2].value);
+
+  ck_assert_int_eq(sizeof(req5) - 1, parse_http_message(req5, sizeof(req5), &ri));
+  ck_assert_str_eq("GET", ri.request_method);
+  ck_assert_str_eq("1.1", ri.http_version);
 }
 END_TEST
 

--- a/test/public.c
+++ b/test/public.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 
 #include "public.h"
+#include <civetweb.h>
 
 /* This unit test file uses the excellent Check unit testing library.
  * The API documentation is available here:

--- a/test/public.c
+++ b/test/public.c
@@ -32,7 +32,19 @@
 
 START_TEST (test_mg_get_cookie)
 {
-  fail_if(0, "s not null after free");
+  char buf[20];
+
+  ck_assert_int_eq(-2, mg_get_cookie("", "foo", NULL, sizeof(buf)));
+  ck_assert_int_eq(-2, mg_get_cookie("", "foo", buf, 0));
+  ck_assert_int_eq(-1, mg_get_cookie("", "foo", buf, sizeof(buf)));
+  ck_assert_int_eq(-1, mg_get_cookie("", NULL, buf, sizeof(buf)));
+  ck_assert_int_eq(1, mg_get_cookie("a=1; b=2; c; d", "a", buf, sizeof(buf)));
+  ck_assert_str_eq("1", buf);
+  ck_assert_int_eq(1, mg_get_cookie("a=1; b=2; c; d", "b", buf, sizeof(buf)));
+  ck_assert_str_eq("2", buf);
+  ck_assert_int_eq(3, mg_get_cookie("a=1; b=123", "b", buf, sizeof(buf)));
+  ck_assert_str_eq("123", buf);
+  ck_assert_int_eq(-1, mg_get_cookie("a=1; b=2; c; d", "c", buf, sizeof(buf)));
 }
 END_TEST
 


### PR DESCRIPTION
This ports the tests from `unit_test.c` into the CTest and check test framework. It can be merged at any time as the tests will provide increased testing coverage under the CMake build system but I will attempt to port as many tests to this branch as possible before merge.

This shows how the unit tests use the provided [check assertions](http://check.sourceforge.net/doc/check_html/check_4.html#Convenience-Test-Functions) to provide good feedback from failed tests. For example, rather than using:

```
ASSERT(strcmp(ri.http_version, "1.1") == 0);
```

We can use:

```
ck_assert_str_eq("1.1", ri.http_version);
```

When the assertion fails, check prints both strings providing a simple and easy feedback method to resolve the issue.

If the issue #163 is resolved, this merge request will report increased coverage statistics as more tests are added to the branch.

This is part of #147
