### PR TITLE
Appveyor fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # Load in the needed CMake modules
+include(CheckIncludeFiles)
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 include(AddCCompilerFlag)
@@ -314,6 +315,9 @@ if (CIVETWEB_ENABLE_CXX)
       FORCE)
   add_cxx_compiler_flag(--coverage COVERAGE)
 endif()
+
+# Check the headers we need
+check_include_files(stdint.h HAVE_STDINT)
 
 # Set up the definitions
 if (${CMAKE_BUILD_TYPE} MATCHES "[Dd]ebug")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -94,6 +94,7 @@ before_build:
     -DCIVETWEB_C_STANDARD=%c_standard%
     -DCIVETWEB_CXX_STANDARD=%cxx_standard%
     ..
+  - appveyor PushArtifact CMakeCache.txt
 
 build_script:
   - appveyor AddMessage -Category Information "Build command '%build%'"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,9 +76,14 @@ before_build:
   - if not "%compiler_path%"=="" (set "PATH=%PATH%;%compiler_path%")
   # git bash conflicts with MinGW makefiles
   - if "%generator%"=="MinGW Makefiles" (set "PATH=%PATH:C:\Program Files (x86)\Git\bin=%")
+  # Useful locations
+  - set "source_path=%cd%"
+  - set "output_path=%source_path%\output"
+  - set "build_path=%output_path%\build"
+  - set "install_path=%output_path%\install"
   # Generate the build files
-  - mkdir output
-  - cd output
+  - mkdir "%build_path%"
+  - cd "%build_path%"
   - cmake --version
   - appveyor AddMessage -Category Information "Generating '%generator%'"
   - cmake
@@ -93,16 +98,24 @@ before_build:
     -DCIVETWEB_ENABLE_LUA_SHARED=%enable_lua_shared%
     -DCIVETWEB_C_STANDARD=%c_standard%
     -DCIVETWEB_CXX_STANDARD=%cxx_standard%
-    ..
+    "%source_path%"
   - appveyor PushArtifact CMakeCache.txt
+  - cd "%source_path%"
 
 build_script:
+  - cd "%build_path%"
   - appveyor AddMessage -Category Information "Build command '%build%'"
   - cmd /c "%build%"
+  - cd "%source_path%"
 
 test_script:
+  - cd "%build_path%"
   - appveyor AddMessage -Category Information "Test command '%build%'"
   - cmd /c "%test%"
+  - cd "%source_path%"
+
+after_test:
+  - cmake "-DCMAKE_INSTALL_PREFIX=%install_path%" -P "%build_path%/cmake_install.cmake"
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,15 +36,19 @@ install:
   - if "%platform%"=="x64" (set arch=x86_64)
   - if "%platform%"=="x86" (set arch=i686)
   # Download the specific version of MinGW
+  - if "%compiler_name%"=="gcc" (@set "mingw_output_folder=C:\mingw-builds")
   - if "%compiler_name%"=="gcc" (
-      for /f %%a in (
+      @for /f %%a in (
         'call mingw.cmd
           /version "%compiler_version%"
           /arch "%arch%"
           /threading "%compiler_threading%"
-          "C:\mingw-builds"'
+          "%mingw_output_folder%"'
       ) do @set "compiler_path=%%a"
     )
+  - if "%compiler_name%"=="gcc" (@set "mingw_log_folder=%mingw_output_folder%\logs")
+  - if exist "%mingw_log_folder%" @for /f %%f in ('dir /b /oD /tc "%mingw_log_folder%"') do @set "mingw_log_file=%mingw_log_folder%\%%f"
+  - if exist "%mingw_log_file%" appveyor PushArtifact "%mingw_log_file%" -FileName mingw-download.log
 
 before_build:
   # Set up mingw commands

--- a/build.cmd
+++ b/build.cmd
@@ -413,16 +413,16 @@
 :log_append - Appends another file into the current logging file
 :: %1 - the file_path to the file to concatenate
 @setlocal
-@set file_path=%~1
+@set "file_path=%~1"
 @if [%file_path%] == [] exit /b 1
 @call :log 3 "Appending to log: %file_path%"
 @call :iso8601 iso8601
-@set temp_log=%temp%\append-%iso8601%.log
+@set "temp_log=%temp%\append-%iso8601%.log"
 @call :log 4 "Using temp file %temp_log%"
 @type "%log_path%" "%file_path%" > "%temp_log%" 2>nul
 @move /y "%temp_log%" "%log_path%" 1>nul
-@del "%file_path% 2>nul
-@del "%temp_log% 2>nul
+@del "%file_path%" 2>nul
+@del "%temp_log%" 2>nul
 @endlocal
 @goto :eof
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,3 @@
-# Check the headers we need
-include(CheckIncludeFiles)
-check_include_files(stdint.h HAVE_STDINT)
-
 # The C API library
 add_library(c-library civetweb.c)
 set_target_properties(c-library PROPERTIES

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -72,11 +72,19 @@ add_executable(civetweb-c-unit-test main.c)
 target_link_libraries(civetweb-c-unit-test public-c-unit-tests private-c-unit-tests ${CHECK_LIBRARIES})
 add_dependencies(civetweb-c-unit-test check)
 
+# A macro for adding tests
+macro(civetweb_add_test suite test_case)
+  set(test "test-${suite}-${test_case}")
+  string(TOLOWER "${test}" test)
+  string(REGEX REPLACE "[^-A-Za-z0-9]" "-" test "${test}")
+  add_test(${test} civetweb-c-unit-test "--suite=${suite}" "--test-case=${test_case}")
+endmacro(civetweb_add_test)
+
 # Public API tests
-add_test(test-public-cookie civetweb-c-unit-test --suite=Public --test-case=Cookies)
+civetweb_add_test(Public Cookies)
 
 # Private API tests
-add_test(test-private-http-message civetweb-c-unit-test --suite=Private "--test-case=HTTP Message")
+civetweb_add_test(Private "HTTP Message")
 
 # Add the coverage command(s)
 if (${CMAKE_BUILD_TYPE} MATCHES "[Cc]overage")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -77,7 +77,12 @@ macro(civetweb_add_test suite test_case)
   set(test "test-${suite}-${test_case}")
   string(TOLOWER "${test}" test)
   string(REGEX REPLACE "[^-A-Za-z0-9]" "-" test "${test}")
-  add_test(${test} civetweb-c-unit-test "--suite=${suite}" "--test-case=${test_case}")
+  add_test(
+    NAME ${test}
+    COMMAND civetweb-c-unit-test "--suite=${suite}" "--test-case=${test_case}")
+  string(REPLACE ";" "\\;" test_path "$ENV{PATH}")
+  set_tests_properties(${test} PROPERTIES
+    ENVIRONMENT "PATH=${test_path}\\;$<TARGET_FILE_DIR:c-library>")
 endmacro(civetweb_add_test)
 
 # Public API tests

--- a/test/civetweb_check.h
+++ b/test/civetweb_check.h
@@ -32,6 +32,8 @@
 #define pid_t int
 /* Unreferenced formal parameter. START_TEST has _i */
 #pragma warning(disable: 4100)
+/* conditional expression is constant . asserts use while(0) */
+#pragma warning(disable: 4127)
 #endif
 #include <stdint.h>
 #include <check.h>

--- a/test/private.c
+++ b/test/private.c
@@ -21,9 +21,12 @@
  */
 
 /**
- * We include the source file so that we access to the internal private
+ * We include the source file so that we have access to the internal private
  * static functions
  */
+#ifdef _MSC_VER
+#define CIVETWEB_API static
+#endif
 #include "../src/civetweb.c"
 
 #include <stdlib.h>


### PR DESCRIPTION
This branch does various things to fix up the build on Appveyor and Windows in general:
  * It adds more output to the mingw download log
  * It uploads the mingw download log as an artefact
  * It uploads the CMake cache as an artefact
  * It fixes up the tests by correcting the environment path and build symbols