### PR TITLE
Use the 5.1.0 version of GCC

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,9 +18,9 @@ environment:
   c_standard: auto
   cxx_standard: auto
   matrix:
-    - compiler: gcc-4.9.2-posix
+    - compiler: gcc-5.1.0-posix
       build_shared: NO
-    - compiler: gcc-4.9.2-posix
+    - compiler: gcc-5.1.0-posix
       build_shared: YES
     - compiler: msvc-18-seh
       build_shared: NO


### PR DESCRIPTION
This is for MinGW builds on Appveyor. I've mainly pushed it to test that Appveyor is doing the right thing on the bel2125 fork of the repository.

Hopefully the Appveyor tests should pass.

This is in response to the failed appveyor test that occured in #167 