### PR TITLE
Cache Appveyor built third party code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,11 @@ if (CIVETWEB_ENABLE_SSL)
   message(STATUS "Dynamically load SSL libraries - ${CIVETWEB_ENABLE_SSL_DYNAMIC_LOADING}")
 endif()
 
+# Third Party Download location
+set(CIVETWEB_THIRD_PARTY_DIR "${CMAKE_BINARY_DIR}/third_party" CACHE STRING
+  "The location that third party code is downloaded, built and installed")
+set_property(CACHE CIVETWEB_THIRD_PARTY_DIR PROPERTY VALUE ${CIVETWEB_THIRD_PARTY_DIR})
+
 # Unix systems can define the dynamic library names to load
 if (CIVETWEB_ENABLE_SSL_DYNAMIC_LOADING AND NOT DARWIN AND UNIX)
   # SSL library name

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -81,6 +81,7 @@ before_build:
   - set "output_path=%source_path%\output"
   - set "build_path=%output_path%\build"
   - set "install_path=%output_path%\install"
+  - set "third_party_dir=C:\third-party"
   # Generate the build files
   - mkdir "%build_path%"
   - cd "%build_path%"
@@ -88,6 +89,7 @@ before_build:
   - appveyor AddMessage -Category Information "Generating '%generator%'"
   - cmake
     -G "%generator%"
+    "-DCIVETWEB_THIRD_PARTY_DIR=%third_party_dir:\=\\%"
     -DCMAKE_BUILD_TYPE=%build_type%
     -DBUILD_SHARED_LIBS=%build_shared%
     -DCIVETWEB_ENABLE_SSL=%enable_ssl%
@@ -122,3 +124,4 @@ matrix:
 
 cache:
   - C:\mingw-builds -> mingw.cmd
+  - C:\third-party -> **\CMakeLists.txt

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,7 +82,7 @@ if (CIVETWEB_ENABLE_LUA)
     ExternalProject_Add(lua
       URL "http://www.lua.org/ftp/lua-${CIVETWEB_LUA_VERSION}.tar.gz"
       URL_MD5 ${CIVETWEB_LUA_MD5_HASH}
-      PREFIX "${CMAKE_BINARY_DIR}/third_party"
+      PREFIX "${CIVETWEB_THIRD_PARTY_DIR}"
       CONFIGURE_COMMAND ""
       BUILD_COMMAND ${LUA_BUILD_COMMAND}
       BUILD_IN_SOURCE 1
@@ -109,7 +109,7 @@ if (CIVETWEB_ENABLE_LUA)
   ExternalProject_Add(luafilesystem
     URL "https://github.com/keplerproject/luafilesystem/archive/v_${LUA_FILESYSTEM_VERSION_UNDERSCORE}.tar.gz"
     URL_MD5 ${CIVETWEB_LUA_FILESYSTEM_MD5_HASH}
-    PREFIX "${CMAKE_BINARY_DIR}/third_party"
+    PREFIX "${CIVETWEB_THIRD_PARTY_DIR}"
     PATCH_COMMAND ${CMAKE_COMMAND} -E copy
       "${CMAKE_SOURCE_DIR}/cmake/luafilesystem/CMakeLists.txt" <SOURCE_DIR>/CMakeLists.txt
     CMAKE_ARGS
@@ -142,7 +142,7 @@ if (CIVETWEB_ENABLE_LUA)
   ExternalProject_Add(luasqlite
     URL "http://lua.sqlite.org/index.cgi/zip/${LUA_SQLITE_FILENAME}"
     URL_MD5 ${CIVETWEB_LUA_SQLITE_MD5_HASH}
-    PREFIX "${CMAKE_BINARY_DIR}/third_party"
+    PREFIX "${CIVETWEB_THIRD_PARTY_DIR}"
     PATCH_COMMAND ${CMAKE_COMMAND} -E copy
       "${CMAKE_SOURCE_DIR}/cmake/luasqlite/CMakeLists.txt" <SOURCE_DIR>/CMakeLists.txt
     CMAKE_ARGS
@@ -172,7 +172,7 @@ if (CIVETWEB_ENABLE_LUA)
   ExternalProject_Add(luaxml
     URL "http://viremo.eludi.net/LuaXML/${LUA_XML_FILENAME}"
     URL_MD5 ${CIVETWEB_LUA_XML_MD5_HASH}
-    PREFIX "${CMAKE_BINARY_DIR}/third_party"
+    PREFIX "${CIVETWEB_THIRD_PARTY_DIR}"
     PATCH_COMMAND ${CMAKE_COMMAND} -E copy
       "${CMAKE_SOURCE_DIR}/cmake/luaxml/CMakeLists.txt" <SOURCE_DIR>/CMakeLists.txt
     CMAKE_ARGS
@@ -200,7 +200,7 @@ if (CIVETWEB_ENABLE_LUA)
   ExternalProject_Add(sqlite
     URL "http://www.sqlite.org/2015/sqlite-amalgamation-${SQLITE_FILE_VERSION}.zip"
     URL_MD5 ${CIVETWEB_SQLITE_MD5_HASH}
-    PREFIX "${CMAKE_BINARY_DIR}/third_party"
+    PREFIX "${CIVETWEB_THIRD_PARTY_DIR}"
     PATCH_COMMAND ${CMAKE_COMMAND} -E copy
       "${CMAKE_SOURCE_DIR}/cmake/sqlite/CMakeLists.txt" <SOURCE_DIR>/CMakeLists.txt
     CMAKE_ARGS

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,7 @@ ExternalProject_Add(check-unit-test-framework
   DEPENDS c-library
   URL "https://downloads.sourceforge.net/project/check/check/${CIVETWEB_CHECK_VERSION}/check-${CIVETWEB_CHECK_VERSION}.tar.gz"
   URL_MD5 ${CIVETWEB_CHECK_MD5_HASH}
-  PREFIX "${CMAKE_BINARY_DIR}/third_party"
+  PREFIX "${CIVETWEB_THIRD_PARTY_DIR}"
   BUILD_IN_SOURCE 1
   PATCH_COMMAND ${CMAKE_COMMAND}
     -DSOURCE_DIR=<SOURCE_DIR>


### PR DESCRIPTION
This branch caches the downloaded the third party code on the Appveyor platform. It seems that the main reason for Appveyor false positives is when downloads fail for external software. The more we can cache the better as the download for the cached files is _much_ faster.