### PR TITLE
Support Sec-WebSocket-Protocol header tag

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -7287,8 +7287,8 @@ static int send_websocket_handshake(struct mg_connection *conn)
 	          "Sec-WebSocket-Accept: ",
 	          b64_sha,
 	          "\r\n");
-
-	if (protocol = mg_get_header(conn, "Sec-WebSocket-Protocol")) {
+	protocol = mg_get_header(conn, "Sec-WebSocket-Protocol");
+	if (protocol) {
 	mg_printf(conn,
 		"%s%s%s",
 		"Sec-WebSocket-Protocol:",

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -7257,6 +7257,7 @@ static void SHA1Final(unsigned char digest[20], SHA1_CTX *context)
 static int send_websocket_handshake(struct mg_connection *conn)
 {
 	static const char *magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+	const char *protocol = NULL;
 	char buf[100], sha[20], b64_sha[sizeof(sha) * 2];
 	SHA1_CTX sha_ctx;
 	int truncated;
@@ -7285,7 +7286,19 @@ static int send_websocket_handshake(struct mg_connection *conn)
 	          "Connection: Upgrade\r\n"
 	          "Sec-WebSocket-Accept: ",
 	          b64_sha,
-	          "\r\n\r\n");
+	          "\r\n");
+
+	if (protocol = mg_get_header(conn, "Sec-WebSocket-Protocol")) {
+	mg_printf(conn,
+		"%s%s%s",
+		"Sec-WebSocket-Protocol:",
+		protocol,
+		"\r\n\r\n");
+	} else {
+		mg_printf(conn,
+			"%s",
+			"\r\n");
+	}
 
 	return 1;
 }


### PR DESCRIPTION
Websocket clients using Sec-WebSocket-Protocol refuse to connect to civetweb server. Error: "Expected a Sec-WebSocket-Protocol header"

The |Sec-WebSocket-Protocol| header field is used in the WebSocket opening handshake.  It is sent from the client to the server and back from the server to the client to confirm the subprotocol of the connection. This enables scripts to both select a subprotocol and be sure that the server agreed to serve that subprotocol.

The changed code will echo the Sec-webSocket-Protocol header to the client.