### PR TITLE
Test directory

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,6 +53,10 @@ if (LIBRT_FOUND)
 endif()
 
 # Build the C unit tests
+add_library(shared-c-unit-tests STATIC shared.c)
+target_include_directories(
+  shared-c-unit-tests PUBLIC
+  ${PROJECT_SOURCE_DIR}/include)
 add_library(public-c-unit-tests STATIC public.c)
 if (BUILD_SHARED_LIBS)
   target_compile_definitions(public-c-unit-tests PRIVATE CIVETWEB_DLL_IMPORTS)
@@ -69,7 +73,11 @@ target_include_directories(
 target_link_libraries(private-c-unit-tests ${CHECK_LIBRARIES})
 add_dependencies(private-c-unit-tests check-unit-test-framework)
 add_executable(civetweb-c-unit-test main.c)
-target_link_libraries(civetweb-c-unit-test public-c-unit-tests private-c-unit-tests ${CHECK_LIBRARIES})
+target_link_libraries(civetweb-c-unit-test
+  shared-c-unit-tests
+  public-c-unit-tests
+  private-c-unit-tests
+  ${CHECK_LIBRARIES})
 add_dependencies(civetweb-c-unit-test check-unit-test-framework)
 
 # Add a check command that builds the dependent test program
@@ -84,7 +92,7 @@ macro(civetweb_add_test suite test_case)
   string(REGEX REPLACE "[^-A-Za-z0-9]" "-" test "${test}")
   add_test(
     NAME ${test}
-    COMMAND civetweb-c-unit-test "--suite=${suite}" "--test-case=${test_case}")
+    COMMAND civetweb-c-unit-test "--test-dir=${CMAKE_CURRENT_SOURCE_DIR}" "--suite=${suite}" "--test-case=${test_case}")
   if (WIN32)
     string(REPLACE ";" "\\;" test_path "$ENV{PATH}")
     set_tests_properties(${test} PROPERTIES

--- a/test/main.c
+++ b/test/main.c
@@ -20,6 +20,7 @@
  */
 
 #include "civetweb_check.h"
+#include "shared.h"
 #include "public.h"
 #include "private.h"
 
@@ -40,15 +41,21 @@ int main(const int argc, const char * const * const argv) {
   const char * test_case = NULL;
   const char * const test_case_arg = "--test-case=";
   const size_t test_case_arg_size = strlen(test_case_arg);
+  const char * const test_dir_arg = "--test-dir=";
+  const size_t test_dir_arg_size = strlen(test_dir_arg);
   for (int i = 1; i < argc; ++i) {
     if (0 == strncmp(suite_arg, argv[i], suite_arg_size) && (strlen(argv[i]) > suite_arg_size)) {
       suite = &argv[i][suite_arg_size];
     } else if (0 == strncmp(test_case_arg, argv[i], test_case_arg_size) && (strlen(argv[i]) > test_case_arg_size)) {
       test_case = &argv[i][test_case_arg_size];
+    } else if (0 == strncmp(test_dir_arg, argv[i], test_dir_arg_size) && (strlen(argv[i]) > test_dir_arg_size)) {
+      set_test_directory(&argv[i][test_dir_arg_size]);
     } else if (0 == strcmp("--help", argv[i])) {
       printf("Usage: %s [options]\n"
         "  --suite=Suite            Determines the suite to run\n"
-        "  --test-case='Test Case'  Determines the test case to run\n",
+        "  --test-case='Test Case'  Determines the test case to run\n"
+        "  --test-dir='folder/path' The location of the test directory with the \n"
+        "                           'fixtures' and 'expected\n",
         argv[0]);
       exit(EXIT_SUCCESS);
     } else {

--- a/test/private.c
+++ b/test/private.c
@@ -353,10 +353,7 @@ START_TEST(test_encode_decode)
 {
 	char buf[128];
 	const char *alpha = "abcdefghijklmnopqrstuvwxyz";
-	const char *alpha_b64_enc = "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo=";
 	const char *nonalpha = " !\"#$%&'()*+,-./0123456789:;<=>?@";
-	const char *nonalpha_b64_enc =
-	    "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj9A";
 	const char *nonalpha_url_enc1 =
 	    "%20%21%22%23$%25%26%27()%2a%2b,-.%2f0123456789%3a;%3c%3d%3e%3f%40";
 	const char *nonalpha_url_enc2 =
@@ -365,6 +362,10 @@ START_TEST(test_encode_decode)
 	size_t len;
 
 #if defined(USE_WEBSOCKET) || defined(USE_LUA)
+	const char *alpha_b64_enc = "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo=";
+	const char *nonalpha_b64_enc =
+	    "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj9A";
+
 	memset(buf, 77, sizeof(buf));
 	base64_encode((unsigned char *)"a", 1, buf);
 	ck_assert_str_eq(buf, "YQ==");

--- a/test/shared.c
+++ b/test/shared.c
@@ -1,0 +1,33 @@
+/* Copyright (c) 2015 the Civetweb developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "shared.h"
+#include <string.h>
+
+static char s_test_directory[1024] = {'\0'};
+
+const char * get_test_directory(void) {
+  return s_test_directory;
+}
+
+void set_test_directory(const char * const path) {
+  strncpy(s_test_directory, path, sizeof(s_test_directory)/sizeof(s_test_directory[0]));
+}

--- a/test/shared.h
+++ b/test/shared.h
@@ -1,0 +1,27 @@
+/* Copyright (c) 2015 the Civetweb developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef TEST_SHARED_H_
+#define TEST_SHARED_H_
+
+const char * get_test_directory(void);
+void set_test_directory(const char * const path);
+
+#endif /* TEST_SHARED_H_ */


### PR DESCRIPTION
Adds the `--test-dir` argument to the unit tests that allows the check unit tests to retrieve the location of the test folder via `get_test_directory` after `#include "shared.h"`

This is set by CMake to `CMAKE_CURRENT_SOURCE_DIR` which will always point to the location of the `test/CMakeLists.txt`